### PR TITLE
Dag para replicar tableros en SenzGT

### DIFF
--- a/dag-senz-gt-clasificar-productos-y-configurar-licencias.py
+++ b/dag-senz-gt-clasificar-productos-y-configurar-licencias.py
@@ -1,0 +1,58 @@
+from airflow import DAG
+from airflow.providers.ssh.operators.ssh import SSHOperator
+from core_transfer import TransferTasks
+from datetime import datetime, timedelta
+
+default_args = {
+    'owner': 'airflow',
+    'email': ['emilianni@kemok.io'],
+    'email_on_success': False,
+    'email_on_failure': True,
+    'email_on_retry': True,
+    'retries': 1,
+    'retry_delay': timedelta(seconds=30),
+    'sla': timedelta(minutes=60)
+}
+with DAG(
+    dag_id='senz-gt-manejo-de-productos-y-demos',
+    description="Réplica y configuración de productos de kemok.",
+    default_args=default_args,
+    schedule_interval=None,
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
+    max_active_runs=1,
+    #dagrun_timeout=timedelta(minutes=350),
+    tags=['senz', 'ssh'],
+) as dag:
+
+    t1 = TransferTasks(client='senz gt', condition='test').task_groups()
+
+    t2 = TransferTasks(client='senz pa', condition='test').task_groups()
+
+    t3 = SSHOperator(
+        task_id='clasificar-productos-y-configurar-licencias',
+        command='cd /opt/productos-guatecompras-senz-gt/ ; python main.py',
+        ssh_conn_id='elt_server',
+        conn_timeout=None,
+        cmd_timeout=36000
+    )
+
+    t4 = SSHOperator(
+        task_id='aplicar-cambios-en-metabase',
+        command='cd /opt/metamanager/ ; python main.py',
+        ssh_conn_id='elt_server',
+        conn_timeout=None,
+        cmd_timeout=36000
+    )
+
+    t5 = SSHOperator(
+        task_id='eliminar-licencias',
+        command='cd /opt/productos-guatecompras-senz-gt/ ; python main.py',
+        ssh_conn_id='elt_server',
+        conn_timeout=None,
+        cmd_timeout=36000
+    )
+
+    t1 >> t3
+    t2 >> t3
+    t3 >> t4 >> t5


### PR DESCRIPTION
Actividad:
Creación de dag para replicar tableros en SenzGT

Cambio:
Se duplico el dag "dag-senz-clasificar-productos-y-configurar-licencias" y se ajusto para que busque el script en el directorio productos-guatecompras-senz-gt que es donde se encuentra el script que inserta los registros de tableros a replicar en metamanager