### PR TITLE
Ef/creacion dag metricas diarias tiendas pos

### DIFF
--- a/dag-sr-tendero-extraccion-cada-media-hora-tiendas-pos.py
+++ b/dag-sr-tendero-extraccion-cada-media-hora-tiendas-pos.py
@@ -16,7 +16,7 @@ with DAG(
     dag_id='sr-tendero-extraccion-cada-media-hora-tiendas-pos',
     description="Extracción desde Tendero_Pos as SrTendero cada media hora",
     default_args=default_args,
-    schedule_interval='*/25 * * * *',
+    schedule_interval='0,25 13-23,0-5 * * *',
     start_date=datetime(2021, 1, 1),
     catchup=False,
     max_active_runs=1,

--- a/dag-sr-tendero-extraccion-cada-media-hora-tiendas-pos.py
+++ b/dag-sr-tendero-extraccion-cada-media-hora-tiendas-pos.py
@@ -1,0 +1,28 @@
+from airflow import DAG
+from core_processing import build_processing_tasks
+from datetime import datetime, timedelta
+from os import getcwd
+
+default_args = {
+    'owner': 'airflow',
+    'email': ['emilianni@kemok.io'],
+    'email_on_success': False,
+    'email_on_failure': True,
+    'email_on_retry': True,
+    'retries': 0,
+    'sla': timedelta(minutes=120)
+}
+with DAG(
+    dag_id='sr-tendero-metricas-diarias-tiendas-pos',
+    description="Extracción desde Tendero_Pos as SrTendero cada media hora",
+    default_args=default_args,
+    schedule_interval='5 0 1 * *',
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
+    max_active_runs=1,
+    dagrun_timeout=timedelta(minutes=350),
+    tags=['sr tendero'],
+) as dag:
+
+    t1 = build_processing_tasks(connection_id='sr_tendero_postgres', repo='sr-tendero-sql/metricas_diarias-tiendas-pos')
+

--- a/dag-sr-tendero-extraccion-cada-media-hora-tiendas-pos.py
+++ b/dag-sr-tendero-extraccion-cada-media-hora-tiendas-pos.py
@@ -13,10 +13,10 @@ default_args = {
     'sla': timedelta(minutes=120)
 }
 with DAG(
-    dag_id='sr-tendero-metricas-diarias-tiendas-pos',
+    dag_id='sr-tendero-extraccion-cada-media-hora-tiendas-pos',
     description="Extracción desde Tendero_Pos as SrTendero cada media hora",
     default_args=default_args,
-    schedule_interval='5 0 1 * *',
+    schedule_interval='*/25 * * * *',
     start_date=datetime(2021, 1, 1),
     catchup=False,
     max_active_runs=1,


### PR DESCRIPTION
Situación: Debido a que se esta habilitando el tablero Reporte diario para Honduras, se hace necesario extraer la ventas diarias de las tiendas POS varias veces en el día.

Actividad: Se creó dag para extraer las ventas diarias de las tiendas POS de los últimos dos días. Se ejecutara cada 25 minutos.