### PR TITLE
Ef/dag respaldo tablas de proyecciones caricam

### DIFF
--- a/dag-respaldo-tablas-proyecciones-y-presentaciones-app-proyecciones.py
+++ b/dag-respaldo-tablas-proyecciones-y-presentaciones-app-proyecciones.py
@@ -1,0 +1,36 @@
+from airflow import DAG
+from airflow.operators.sql import BranchSQLOperator
+from airflow.providers.airbyte.operators.airbyte import AirbyteTriggerSyncOperator
+from airflow.providers.airbyte.sensors.airbyte import AirbyteJobSensor
+from airflow.operators.dummy import DummyOperator
+from core_processing import build_processing_tasks
+from datetime import datetime, timedelta
+from os import getcwd
+
+PATH = getcwd() + '/dags/'
+
+default_args = {
+    'owner': 'airflow',
+    'email': ['emilianni@kemok.io'],
+    'email_on_success': False,
+    'email_on_failure': True,
+    'email_on_retry': True,
+    'retries': 0,
+    'sla': timedelta(minutes=120)
+}
+with DAG(
+    dag_id='bago-caricam-respaldo-tablas-proyecciones-y-presentaciones',
+    description="Respalda dos tablas de la app proyecciones",
+    default_args=default_args,
+    schedule_interval=None,
+    schedule_interval='0 9 30 * *',
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
+    max_active_runs=1,
+    dagrun_timeout=timedelta(minutes=350),
+    tags=['bago caricam', 'airbyte'],
+) as dag:
+
+    t1 = build_processing_tasks(connection_id='bago_caricam_app', repo='bago_caricam_sql/respaldo-tablas-app-proyecciones')                                                                       
+
+    t1 

--- a/dag-respaldo-tablas-proyecciones-y-presentaciones-app-proyecciones.py
+++ b/dag-respaldo-tablas-proyecciones-y-presentaciones-app-proyecciones.py
@@ -21,8 +21,7 @@ default_args = {
 with DAG(
     dag_id='bago-caricam-respaldo-tablas-proyecciones-y-presentaciones',
     description="Respalda dos tablas de la app proyecciones",
-    default_args=default_args,
-    schedule_interval=None,
+    default_args=default_args,    
     schedule_interval='0 9 30 * *',
     start_date=datetime(2021, 1, 1),
     catchup=False,


### PR DESCRIPTION
Situación: Se hace necesario respaldar las tablas proyecciones y presentaciones de la App proyecciones de Bagó Caricam, para evitar perder proyecciones no aprobadas al finalizar el mes.
